### PR TITLE
exported `err` variables should be of type error

### DIFF
--- a/license.go
+++ b/license.go
@@ -24,11 +24,13 @@ const (
 	LicenseCDDL10    = "CDDL-1.0"
 	LicenseEPL10     = "EPL-1.0"
 	LicenseUnlicense = "Unlicense"
+)
 
+var (
 	// Various errors
-	ErrNoLicenseFile       = "license: unable to find any license file"
-	ErrUnrecognizedLicense = "license: could not guess license type"
-	ErrMultipleLicenses    = "license: multiple license files found"
+	ErrNoLicenseFile       = errors.New("license: unable to find any license file")
+	ErrUnrecognizedLicense = errors.New("license: could not guess license type")
+	ErrMultipleLicenses    = errors.New("license: multiple license files found")
 )
 
 // A set of reasonable license file names to use when guessing where the
@@ -210,7 +212,7 @@ func (l *License) GuessType() error {
 		l.Type = LicenseUnlicense
 
 	default:
-		return errors.New(ErrUnrecognizedLicense)
+		return ErrUnrecognizedLicense
 	}
 
 	return nil
@@ -257,10 +259,10 @@ func getLicenseFile(licenses []string, files []string) (string, error) {
 
 	switch len(matches) {
 	case 0:
-		return "", errors.New(ErrNoLicenseFile)
+		return "", ErrNoLicenseFile
 	case 1:
 		return matches[0], nil
 	default:
-		return "", errors.New(ErrMultipleLicenses)
+		return "", ErrMultipleLicenses
 	}
 }

--- a/license_test.go
+++ b/license_test.go
@@ -1,7 +1,6 @@
 package license
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -213,9 +212,9 @@ func TestGetLicenseFile(t *testing.T) {
 		want  string
 		err   error
 	}{
-		{[]string{".", "junk", "COPYING"}, "COPYING", nil},                                // 1 match
-		{[]string{"junk", "copy"}, "", errors.New(ErrNoLicenseFile)},                      // 0 match
-		{[]string{"COPYING", "junk", "Copying.txt"}, "", errors.New(ErrMultipleLicenses)}, // 2 match
+		{[]string{".", "junk", "COPYING"}, "COPYING", nil},                    // 1 match
+		{[]string{"junk", "copy"}, "", ErrNoLicenseFile},                      // 0 match
+		{[]string{"COPYING", "junk", "Copying.txt"}, "", ErrMultipleLicenses}, // 2 match
 	}
 
 	for pos, tt := range tests {


### PR DESCRIPTION
Ohai! Cool package! 

This changes the `ErrXxx` things to be of type `error`. Why? It's not good practice to match errors based on their `.String()` value. If the package's exporter `ErrXxx..` are of type `string`, it encourages users to do just that.

r: @ryanuber 