### PR TITLE
MPLv2 is sometime stated without a comma

### DIFF
--- a/license.go
+++ b/license.go
@@ -187,7 +187,7 @@ func (l *License) GuessType() error {
 		"version 3, 19 november 2007"):
 		l.Type = LicenseAGPL30
 
-	case scan(comp, "mozilla public license, version 2.0"):
+	case scan(comp, "mozilla public license") && scan(comp, "version 2.0"):
 		l.Type = LicenseMPL20
 
 	case scan(comp, "redistribution and use in source and binary forms"):


### PR DESCRIPTION
For instance, in `github.com/hashicorp/go-sockaddr` the MPLv2 starts like:

```
Mozilla Public License Version 2.0
```
> https://github.com/hashicorp/go-sockaddr/blob/master/LICENSE#L1

I think long term it'd be better to tokenize the licenses and do some sort of TF-IDF matching.